### PR TITLE
Moves 'distro_version_id' from a property on Package to an argument to Client#put_package

### DIFF
--- a/lib/packagecloud/package.rb
+++ b/lib/packagecloud/package.rb
@@ -14,8 +14,16 @@ module Packagecloud
       raise ArgumentError, 'file cannot be nil' if file.nil?
       @file = file
       @filename = filename
-      @distro_version_id = distro_version_id
+      if distro_version_id
+        @distro_version_id = distro_version_id
+      end
       @source_files = source_files
+    end
+
+    def distro_version_id=(distro_version_id)
+      deprec = "[DEPRECATION] distro_version_id on Package is deprecated, please pass distro_version_id to Client#put_package instead"
+      warn deprec if distro_version_id
+      @distro_version_id = distro_version_id
     end
 
   end

--- a/lib/packagecloud/version.rb
+++ b/lib/packagecloud/version.rb
@@ -1,7 +1,7 @@
 module Packagecloud
   MAJOR_VERSION = "0"
   MINOR_VERSION = "2"
-  PATCH_VERSION = "20"
+  PATCH_VERSION = "21"
 
   VERSION = [MAJOR_VERSION, MINOR_VERSION, PATCH_VERSION].join(".")
 end


### PR DESCRIPTION
This is the start of a change to make the Package domain model agnostic to distributions. 

The primary use case for this is to be able to upload the same Package object to multiple distributions like so:

```ruby
pkg = Package.new(open('/tmp/mypkg.deb'))

client.put_package(pkg, 'ubuntu/utopic')
client.put_package(pkg, 'debian/wheezy')
```

As a bonus, it's now possible to lookup distributions by name, much like our command line tool.

We still handle the older case where `distro_version_id` is set on Package, which we'll presumably turn off in a future major version release.
