### PR TITLE
Remove JSON::Pure to resolve conflict between JSON::Pure and JSON::Ext

### DIFF
--- a/lib/packagecloud/client.rb
+++ b/lib/packagecloud/client.rb
@@ -1,4 +1,4 @@
-require 'json/pure'
+require 'json/pure' unless JSON::Ext
 require 'mime'
 require 'excon'
 require 'packagecloud/result'


### PR DESCRIPTION
When integrate in rails, require JSON::Pure will conflict with JSON::Ext as JSON::Ext is already loaded from rails. Suggest to check if JSON::Ext is loaded before require JSON::Pure.